### PR TITLE
hook: simplify contexts

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -65,12 +65,6 @@ func (ctxt *Context) withLocalStateName(localStateName string) *Context {
 	}
 }
 
-// LocalContext transforms an existing
-// context into a context with state local to r.
-func (r *Registry) LocalContext(ctxt *Context) *Context {
-	return ctxt.withLocalStateName(r.localStateName)
-}
-
 // hookStateDir is where hook local state will be stored.
 var hookStateDir = "/var/lib/juju-localstate"
 


### PR DESCRIPTION
Rather than passing the context in with the callback,
we provide a way to set the context when the hook
executes.

This means that exactly the same set of objects can
be used at registration time as hook execution time.
