### PR TITLE
charmbits/service: allow the passing of arguments to the service

### DIFF
--- a/charmbits/service/server.go
+++ b/charmbits/service/server.go
@@ -1,33 +1,73 @@
 package service
 
 import (
-	"flag"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/rpc"
+	"net/rpc/jsonrpc"
 	"os"
 
 	"launchpad.net/errgo/errors"
 )
 
-func runServer(serviceRPC interface{}, args []string) {
-	os.Args = append([]string{"runhook"}, args...)
-	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: service <socketpath>\n")
-		flag.PrintDefaults()
-		os.Exit(2)
+type serviceParams struct {
+	SocketPath string
+	Args       []string
+}
+
+// runServer runs the server side of the service. It is invoked
+// (indirectly) by upstart.
+func runServer(start func(ctxt *Context, args []string), args []string) {
+	if len(args) != 1 {
+		fatalf("expected exactly one argument, found %q", args)
 	}
-	flag.Parse()
-	if flag.NArg() != 1 {
-		flag.Usage()
-	}
-	listener, err := listen(flag.Arg(0))
+	pdata, err := base64.StdEncoding.DecodeString(args[0])
 	if err != nil {
-		fatalf("cannot listen: %v", err)
+		fatalf("cannot base64 decode argument: %v", err)
 	}
+	var p serviceParams
+	if err := json.Unmarshal(pdata, &p); err != nil {
+		fatalf("cannot json unmarshal argument %q: %v", pdata, err)
+	}
+	ctxt := &Context{
+		socketPath: p.SocketPath,
+	}
+	start(ctxt, p.Args)
+}
+
+func fatalf(f string, a ...interface{}) {
+	fmt.Fprintln(os.Stderr, fmt.Sprintf(f, a...))
+	os.Exit(2)
+}
+
+// Context holds the context provided to a running service.
+type Context struct {
+	socketPath string
+}
+
+// ServeLocalRPC starts a local RPC server serving methods on the given
+// receiver value, using the net/rpc package (see rpc.Server.Register).
+//
+// The methods may be invoked using the Service.Call method. Parameters
+// and return values will be marshaled as JSON.
+//
+// ServeLocalRPC blocks indefinitely.
+func (ctxt *Context) ServeLocalRPC(rcvr interface{}) error {
 	srv := rpc.NewServer()
-	srv.Register(serviceRPC)
-	srv.Accept(listener)
+	srv.Register(rcvr)
+	listener, err := listen(ctxt.socketPath)
+	if err != nil {
+		return errors.Wrapf(err, "cannot listen on local socket")
+	}
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return errors.Wrapf(err, "local socket accept failed")
+		}
+		go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+	}
 }
 
 func listen(socketPath string) (net.Listener, error) {
@@ -38,9 +78,4 @@ func listen(socketPath string) (net.Listener, error) {
 		return nil, errors.Wrapf(err, "cannot listen on unix socket")
 	}
 	return listener, err
-}
-
-func fatalf(f string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, f, a...)
-	os.Exit(1)
 }

--- a/example-charms/concat/http.go
+++ b/example-charms/concat/http.go
@@ -1,11 +1,46 @@
 package concat
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
+
+	"launchpad.net/errgo/errors"
+
+	"github.com/juju/gocharm/charmbits/service"
 )
+
+// startServer starts the server running. The
+// actual HTTP server will not start until the
+// initial value and port have been set.
+func startServer(ctxt *service.Context, args []string) {
+	if len(args) != 1 {
+		fatalf("need exactly one argument, got %q", args)
+		os.Exit(2)
+	}
+	srv := &ConcatServer{
+		stateDir: args[0],
+	}
+	state, err := srv.loadState()
+	if err != nil {
+		fatalf("cannot load state: %v", err)
+	}
+	if err := srv.set(state); err != nil {
+		fatalf("cannot set initial state: %v", err)
+	}
+	ctxt.ServeLocalRPC(srv)
+}
+
+func fatalf(f string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, "%s\n", fmt.Sprintf(f, a...))
+	os.Exit(1)
+}
 
 // ConcatServer defines the operations on the service's local
 // RPC server that is used for communication between the
@@ -14,39 +49,57 @@ import (
 // Note that this type must be exported because of
 // the rules about net/rpc types.
 type ConcatServer struct {
-	mu      sync.Mutex
-	port    int
-	val     string
-	started bool
+	mu       sync.Mutex
+	stateDir string
+	state    ServerState
+	listener net.Listener
 }
 
-// StartParams holds the parameters for a ConcatServer.Start call.
-type StartParams struct {
+// ServerState holds the state of a server.
+type ServerState struct {
+	Val  string
 	Port int
 }
 
-// Start starts the service running with the given start parameters.
-// This should only be called once, just after the service is run.
-func (svc *ConcatServer) Start(p *StartParams, _ *struct{}) error {
+// SetVal sets the current value served by the HTTP server
+// and starts the server running if it is not already started.
+func (svc *ConcatServer) Set(p *ServerState, _ *struct{}) error {
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
-	if svc.started {
-		return fmt.Errorf("server already started")
+	if err := svc.set(*p); err != nil {
+		return errors.Wrapf(err, "canot set server state")
 	}
-	go http.ListenAndServe(":"+strconv.Itoa(p.Port), http.HandlerFunc(svc.serveHTTP))
-	svc.started = true
+	if err := svc.saveState(svc.state); err != nil {
+		return errors.Wrapf(err, "cannot save server state")
+	}
 	return nil
 }
 
-// SetValParams holds the parameters for a ConcatServer.SetVal call.
-type SetValParams struct {
-	Val string
-}
-
-func (svc *ConcatServer) SetVal(p *SetValParams, _ *struct{}) error {
-	svc.mu.Lock()
-	defer svc.mu.Unlock()
-	svc.val = p.Val
+// set sets the current state of the server, and starts
+// or restarts the HTTP listener when appropriate.
+func (svc *ConcatServer) set(state ServerState) error {
+	if state.Port == 0 || state.Port != svc.state.Port {
+		if svc.listener != nil {
+			svc.listener.Close()
+			svc.listener = nil
+		}
+	}
+	if state.Port != 0 {
+		addr := ":" + strconv.Itoa(state.Port)
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		svc.listener = listener
+		go func() {
+			server := &http.Server{
+				Addr:    addr,
+				Handler: http.HandlerFunc(svc.serveHTTP),
+			}
+			server.Serve(svc.listener)
+		}()
+	}
+	svc.state = state
 	return nil
 }
 
@@ -64,8 +117,39 @@ func (svc *ConcatServer) serveHTTP(w http.ResponseWriter, req *http.Request) {
 	defer svc.mu.Unlock()
 	switch req.Method {
 	case "GET":
-		fmt.Fprintf(w, "%s", svc.val)
+		fmt.Fprintf(w, "%s", svc.state.Val)
 	default:
 		http.Error(w, "unsupported method", http.StatusBadRequest)
 	}
+}
+
+func (svc *ConcatServer) saveState(state ServerState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return errors.Wrap(err)
+	}
+	path := svc.statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errors.Wrap(err)
+	}
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+func (svc *ConcatServer) loadState() (ServerState, error) {
+	data, err := ioutil.ReadFile(svc.statePath())
+	if err != nil {
+		return ServerState{}, errors.Wrap(err)
+	}
+	var state ServerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ServerState{}, errors.Wrapf(err, "cannot unmarshal state %q", data)
+	}
+	return state, nil
+}
+
+func (svc *ConcatServer) statePath() string {
+	return filepath.Join(svc.stateDir, "serverstate.json")
 }


### PR DESCRIPTION
Also change the interface so that the client gets to decide exactly when
or whether to start the local RPC service, introducing a service.Context type.
