### PR TITLE
hook: add execToolRunner and tool runner benchmark

### DIFF
--- a/hook/export_test.go
+++ b/hook/export_test.go
@@ -7,6 +7,8 @@ var (
 	CtxtRelationUnits      = (*Context).relationUnits
 	CtxtRelationIds        = (*Context).relationIds
 	ValidHookName          = validHookName
+	ExecHookTools          = &execHookTools
+	JujucSymlinks          = &jujucSymlinks
 )
 
 type JujucRequest jujucRequest

--- a/hook/runner.go
+++ b/hook/runner.go
@@ -1,8 +1,10 @@
 package hook
 
 import (
+	"bytes"
 	"net/rpc"
 	"os"
+	osexec "os/exec"
 	"strings"
 
 	"github.com/juju/utils/exec"
@@ -17,6 +19,23 @@ type ToolRunner interface {
 	Close() error
 }
 
+var (
+	// execHookTools specifes whether the hook tools should be called
+	// using os/exec (the conventional way). When this is false,
+	// hook tools are invoked directly through the unix-domain socket
+	// (technically breaking abstraction boundaries but 250 times faster
+	// and easier to test)
+	execHookTools = false
+
+	// jujucSymlinks specifies whether we invoke the hook tools by name.
+	// For testing purposes, setting this to false means that an installed
+	// version of jujud can be used to test the hook logic without creating
+	// symbolic links for all the hook tools.
+	//
+	// This only has an effect when useJujudSocket is false.
+	jujucSymlinks = true
+)
+
 type socketToolRunner struct {
 	contextId   string
 	jujucClient *rpc.Client
@@ -26,6 +45,9 @@ type socketToolRunner struct {
 // that uses a direct connection to the unit agent's socket to
 // run the tools.
 func newToolRunnerFromEnvironment() (ToolRunner, error) {
+	if execHookTools {
+		return execToolRunner{}, nil
+	}
 	path := os.Getenv(envSocketPath)
 	if path == "" {
 		return nil, errors.New("no juju socket found")
@@ -44,9 +66,11 @@ func newToolRunnerFromEnvironment() (ToolRunner, error) {
 	}, nil
 }
 
-// jujucRequest contains the information necessary to run a Command remotely.
-// It is copied from github.com/juju/juju/worker/uniter/context/jujuc
-// so that we can avoid that dependency in non-test code.
+// jujucRequest contains the information necessary to run a Command
+// remotely.
+//
+// It is copied from github.com/juju/juju/worker/uniter/context/jujuc so
+// that we can avoid that dependency in non-test code.
 type jujucRequest struct {
 	ContextId   string
 	Dir         string
@@ -63,7 +87,6 @@ func (r *socketToolRunner) Run(cmd string, args ...string) (stdout []byte, err e
 		CommandName: cmd,
 		Args:        args,
 	}
-	// log.Printf("run req %#v", req)
 	var resp exec.ExecResponse
 	err = r.jujucClient.Call("Jujuc.Main", req, &resp)
 	if err != nil {
@@ -73,12 +96,38 @@ func (r *socketToolRunner) Run(cmd string, args ...string) (stdout []byte, err e
 		return resp.Stdout, nil
 	}
 	errText := strings.TrimSpace(string(resp.Stderr))
-	if strings.HasPrefix(errText, "error: ") {
-		errText = errText[len("error: "):]
-	}
+	errText = strings.TrimPrefix(errText, "error: ")
 	return nil, errors.New(errText)
 }
 
 func (r *socketToolRunner) Close() error {
 	return errors.Wrap(r.jujucClient.Close())
+}
+
+type execToolRunner struct{}
+
+func (execToolRunner) Run(cmd string, args ...string) ([]byte, error) {
+	execCmd := cmd
+	if !jujucSymlinks {
+		execCmd = "jujud"
+	}
+	c := osexec.Command(execCmd, args...)
+	c.Args[0] = cmd
+	var errBuf, outBuf bytes.Buffer
+	c.Stdout = &outBuf
+	c.Stderr = &errBuf
+
+	if err := c.Run(); err != nil {
+		if errBuf.Len() > 0 {
+			errText := strings.TrimSpace(errBuf.String())
+			errText = strings.TrimPrefix(errText, "error: ")
+			return nil, errors.New(errText)
+		}
+		return nil, err
+	}
+	return outBuf.Bytes(), nil
+}
+
+func (execToolRunner) Close() error {
+	return nil
 }


### PR DESCRIPTION
This is the way that the hook tools are intended to be run.
We don't make it the default because a) it's harder to test
and b) it's much slower (getting details on 200 relations
takes ~4 seconds using exec, and 0.02 seconds using the
socket)
