### PR TITLE
vendored: vendor upstart package from juju-core to avoid depending directly on juju-core

### DIFF
--- a/charmbits/service/upstart.go
+++ b/charmbits/service/upstart.go
@@ -3,8 +3,8 @@ package service
 import (
 	"strings"
 
-	"github.com/juju/juju/service/common"
-	"github.com/juju/juju/service/upstart"
+	"github.com/juju/gocharm/vendored/service/common"
+	"github.com/juju/gocharm/vendored/service/upstart"
 )
 
 // OSServiceParams holds the parameters for

--- a/vendored/README
+++ b/vendored/README
@@ -1,0 +1,1 @@
+We've vendored the juju service package in here to avoid depending on juju-core.

--- a/vendored/service/common/common.go
+++ b/vendored/service/common/common.go
@@ -1,0 +1,25 @@
+package common
+
+// Conf is responsible for defining services. Its fields
+// represent elements of a service configuration.
+type Conf struct {
+	// Desc is the upstart service's description.
+	Desc string
+	// Env holds the environment variables that will be set when the command runs.
+	// Currently not used on Windows
+	Env map[string]string
+	// Limit holds the ulimit values that will be set when the command runs.
+	// Currently not used on Windows
+	Limit map[string]string
+	// Cmd is the command (with arguments) that will be run.
+	// The command will be restarted if it exits with a non-zero exit code.
+	Cmd string
+	// Out, if set, will redirect output to that path.
+	Out string
+	// InitDir is the folder in which the init/upstart script should be written
+	// defaults to "/etc/init" on Ubuntu
+	// Currently not used on Windows
+	InitDir string
+	// ExtraScript allows to insert script before command execution
+	ExtraScript string
+}

--- a/vendored/service/upstart/service.go
+++ b/vendored/service/upstart/service.go
@@ -1,0 +1,40 @@
+// Copyright 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upstart
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/juju/utils"
+
+	"github.com/juju/gocharm/vendored/service/common"
+)
+
+const (
+	maxAgentFiles = 20000
+)
+
+// MachineAgentUpstartService returns the upstart config for a machine agent
+// based on the tag and machineId passed in.
+func MachineAgentUpstartService(name, toolsDir, dataDir, logDir, tag, machineId string, env map[string]string) *Service {
+	logFile := path.Join(logDir, tag+".log")
+	// The machine agent always starts with debug turned on.  The logger worker
+	// will update this to the system logging environment as soon as it starts.
+	conf := common.Conf{
+		Desc: fmt.Sprintf("juju %s agent", tag),
+		Limit: map[string]string{
+			"nofile": fmt.Sprintf("%d %d", maxAgentFiles, maxAgentFiles),
+		},
+		Cmd: path.Join(toolsDir, "jujud") +
+			" machine" +
+			" --data-dir " + utils.ShQuote(dataDir) +
+			" --machine-id " + machineId +
+			" --debug",
+		Out: logFile,
+		Env: env,
+	}
+	svc := NewService(name, conf)
+	return svc
+}

--- a/vendored/service/upstart/upstart.go
+++ b/vendored/service/upstart/upstart.go
@@ -1,0 +1,249 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upstart
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"text/template"
+	"time"
+
+	"github.com/juju/errors"
+	"github.com/juju/utils"
+
+	"github.com/juju/gocharm/vendored/service/common"
+)
+
+var startedRE = regexp.MustCompile(`^.* start/running, process (\d+)\n$`)
+
+// InitDir holds the default init directory name.
+var InitDir = "/etc/init"
+
+var InstallStartRetryAttempts = utils.AttemptStrategy{
+	Total: 1 * time.Second,
+	Delay: 250 * time.Millisecond,
+}
+
+// Service provides visibility into and control over an upstart service.
+type Service struct {
+	Name string
+	Conf common.Conf
+}
+
+func NewService(name string, conf common.Conf) *Service {
+	if conf.InitDir == "" {
+		conf.InitDir = InitDir
+	}
+	return &Service{Name: name, Conf: conf}
+}
+
+// confPath returns the path to the service's configuration file.
+func (s *Service) confPath() string {
+	return path.Join(s.Conf.InitDir, s.Name+".conf")
+}
+
+func (s *Service) UpdateConfig(conf common.Conf) {
+	s.Conf = conf
+}
+
+// validate returns an error if the service is not adequately defined.
+func (s *Service) validate() error {
+	if s.Name == "" {
+		return errors.New("missing Name")
+	}
+	if s.Conf.InitDir == "" {
+		return errors.New("missing InitDir")
+	}
+	if s.Conf.Desc == "" {
+		return errors.New("missing Desc")
+	}
+	if s.Conf.Cmd == "" {
+		return errors.New("missing Cmd")
+	}
+	return nil
+}
+
+// render returns the upstart configuration for the service as a slice of bytes.
+func (s *Service) render() ([]byte, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := confT.Execute(&buf, s.Conf); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Installed returns whether the service configuration exists in the
+// init directory.
+func (s *Service) Installed() bool {
+	_, err := os.Stat(s.confPath())
+	return err == nil
+}
+
+// Exists returns whether the service configuration exists in the
+// init directory with the same content that this Service would have
+// if installed.
+func (s *Service) Exists() bool {
+	// In any error case, we just say it doesn't exist with this configuration.
+	// Subsequent calls into the Service will give the caller more useful errors.
+	_, same, _, err := s.existsAndSame()
+	if err != nil {
+		return false
+	}
+	return same
+}
+
+func (s *Service) existsAndSame() (exists, same bool, conf []byte, err error) {
+	expected, err := s.render()
+	if err != nil {
+		return false, false, nil, errors.Trace(err)
+	}
+	current, err := ioutil.ReadFile(s.confPath())
+	if err != nil {
+		if os.IsNotExist(err) {
+			// no existing config
+			return false, false, expected, nil
+		}
+		return false, false, nil, errors.Trace(err)
+	}
+	return true, bytes.Equal(current, expected), expected, nil
+}
+
+// Running returns true if the Service appears to be running.
+func (s *Service) Running() bool {
+	cmd := exec.Command("status", "--system", s.Name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return startedRE.Match(out)
+}
+
+// Start starts the service.
+func (s *Service) Start() error {
+	if s.Running() {
+		return nil
+	}
+	err := runCommand("start", "--system", s.Name)
+	if err != nil {
+		// Double check to see if we were started before our command ran.
+		if s.Running() {
+			return nil
+		}
+	}
+	return err
+}
+
+func runCommand(args ...string) error {
+	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	out = bytes.TrimSpace(out)
+	if len(out) > 0 {
+		return fmt.Errorf("exec %q: %v (%s)", args, err, out)
+	}
+	return fmt.Errorf("exec %q: %v", args, err)
+}
+
+// Stop stops the service.
+func (s *Service) Stop() error {
+	if !s.Running() {
+		return nil
+	}
+	return runCommand("stop", "--system", s.Name)
+}
+
+// StopAndRemove stops the service and then deletes the service
+// configuration from the init directory.
+func (s *Service) StopAndRemove() error {
+	if !s.Installed() {
+		return nil
+	}
+	if err := s.Stop(); err != nil {
+		return err
+	}
+	return os.Remove(s.confPath())
+}
+
+// Remove deletes the service configuration from the init directory.
+func (s *Service) Remove() error {
+	if !s.Installed() {
+		return nil
+	}
+	return os.Remove(s.confPath())
+}
+
+// Install installs and starts the service.
+func (s *Service) Install() error {
+	exists, same, conf, err := s.existsAndSame()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if same {
+		return nil
+	}
+	if exists {
+		if err := s.StopAndRemove(); err != nil {
+			return errors.Annotate(err, "upstart: could not remove installed service")
+		}
+
+	}
+	if err := ioutil.WriteFile(s.confPath(), conf, 0644); err != nil {
+		return errors.Trace(err)
+	}
+
+	// On slower disks, upstart may take a short time to realise
+	// that there is a service there.
+	for attempt := InstallStartRetryAttempts.Start(); attempt.Next(); {
+		if err = s.Start(); err == nil {
+			break
+		}
+	}
+	return err
+}
+
+// InstallCommands returns shell commands to install and start the service.
+func (s *Service) InstallCommands() ([]string, error) {
+	conf, err := s.render()
+	if err != nil {
+		return nil, err
+	}
+	return []string{
+		fmt.Sprintf("cat >> %s << 'EOF'\n%sEOF\n", s.confPath(), conf),
+		"start " + s.Name,
+	}, nil
+}
+
+// BUG: %q quoting does not necessarily match libnih quoting rules
+// (as used by upstart); this may become an issue in the future.
+var confT = template.Must(template.New("").Parse(`
+description "{{.Desc}}"
+author "Juju Team <juju@lists.ubuntu.com>"
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+normal exit 0
+{{range $k, $v := .Env}}env {{$k}}={{$v|printf "%q"}}
+{{end}}
+{{range $k, $v := .Limit}}limit {{$k}} {{$v}}
+{{end}}
+script
+{{if .ExtraScript}}{{.ExtraScript}}{{end}}
+{{if .Out}}
+  # Ensure log files are properly protected
+  touch {{.Out}}
+  chown syslog:syslog {{.Out}}
+  chmod 0600 {{.Out}}
+{{end}}
+  exec {{.Cmd}}{{if .Out}} >> {{.Out}} 2>&1{{end}}
+end script
+`[1:]))

--- a/vendored/service/upstart/upstart_test.go
+++ b/vendored/service/upstart/upstart_test.go
@@ -1,0 +1,303 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package upstart_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	coretesting "github.com/juju/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	"github.com/juju/utils"
+	"github.com/juju/utils/symlink"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/gocharm/vendored/service/common"
+	"github.com/juju/gocharm/vendored/service/upstart"
+)
+
+func Test(t *testing.T) { gc.TestingT(t) }
+
+type UpstartSuite struct {
+	coretesting.BaseSuite
+	testPath string
+	service  *upstart.Service
+	initDir  string
+}
+
+var _ = gc.Suite(&UpstartSuite{})
+
+func (s *UpstartSuite) SetUpTest(c *gc.C) {
+	s.testPath = c.MkDir()
+	s.initDir = c.MkDir()
+	s.PatchEnvPathPrepend(s.testPath)
+	s.PatchValue(&upstart.InstallStartRetryAttempts, utils.AttemptStrategy{})
+	s.PatchValue(&upstart.InitDir, s.initDir)
+	s.service = upstart.NewService(
+		"some-service",
+		common.Conf{
+			Desc: "some service",
+			Cmd:  "some command",
+		},
+	)
+}
+
+var checkargs = `
+#!/bin/bash --norc
+if [ "$1" != "--system" ]; then
+  exit 255
+fi
+if [ "$2" != "some-service" ]; then
+  exit 255
+fi
+if [ "$3" != "" ]; then
+  exit 255
+fi
+`[1:]
+
+func (s *UpstartSuite) MakeTool(c *gc.C, name, script string) {
+	path := filepath.Join(s.testPath, name)
+	err := ioutil.WriteFile(path, []byte(checkargs+script), 0755)
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpstartSuite) StoppedStatus(c *gc.C) {
+	s.MakeTool(c, "status", `echo "some-service stop/waiting"`)
+}
+
+func (s *UpstartSuite) RunningStatus(c *gc.C) {
+	s.MakeTool(c, "status", `echo "some-service start/running, process 123"`)
+}
+
+func (s *UpstartSuite) TestInitDir(c *gc.C) {
+	svc := upstart.NewService("blah", common.Conf{})
+	c.Assert(svc.Conf.InitDir, gc.Equals, s.initDir)
+}
+
+func (s *UpstartSuite) goodInstall(c *gc.C) {
+	s.MakeTool(c, "start", "exit 0")
+	err := s.service.Install()
+	c.Assert(err, jc.ErrorIsNil)
+}
+
+func (s *UpstartSuite) TestInstalled(c *gc.C) {
+	c.Assert(s.service.Installed(), jc.IsFalse)
+	s.goodInstall(c)
+	c.Assert(s.service.Installed(), jc.IsTrue)
+}
+
+func (s *UpstartSuite) TestExists(c *gc.C) {
+	// Setup creates the file, but it is empty.
+	c.Assert(s.service.Exists(), jc.IsFalse)
+	s.goodInstall(c)
+	c.Assert(s.service.Exists(), jc.IsTrue)
+}
+
+func (s *UpstartSuite) TestExistsNonEmpty(c *gc.C) {
+	s.goodInstall(c)
+	s.service.Conf.Cmd = "something else"
+	c.Assert(s.service.Exists(), jc.IsFalse)
+}
+
+func (s *UpstartSuite) TestRunning(c *gc.C) {
+	s.MakeTool(c, "status", "exit 1")
+	c.Assert(s.service.Running(), jc.IsFalse)
+	s.MakeTool(c, "status", `echo "GIBBERISH NONSENSE"`)
+	c.Assert(s.service.Running(), jc.IsFalse)
+	s.RunningStatus(c)
+	c.Assert(s.service.Running(), jc.IsTrue)
+}
+
+func (s *UpstartSuite) TestStart(c *gc.C) {
+	s.RunningStatus(c)
+	s.MakeTool(c, "start", "exit 99")
+	c.Assert(s.service.Start(), gc.IsNil)
+	s.StoppedStatus(c)
+	c.Assert(s.service.Start(), gc.ErrorMatches, ".*exit status 99.*")
+	s.MakeTool(c, "start", "exit 0")
+	c.Assert(s.service.Start(), gc.IsNil)
+}
+
+func (s *UpstartSuite) TestStop(c *gc.C) {
+	s.StoppedStatus(c)
+	s.MakeTool(c, "stop", "exit 99")
+	c.Assert(s.service.Stop(), gc.IsNil)
+	s.RunningStatus(c)
+	c.Assert(s.service.Stop(), gc.ErrorMatches, ".*exit status 99.*")
+	s.MakeTool(c, "stop", "exit 0")
+	c.Assert(s.service.Stop(), gc.IsNil)
+}
+
+func (s *UpstartSuite) TestRemoveMissing(c *gc.C) {
+	c.Assert(s.service.StopAndRemove(), gc.IsNil)
+}
+
+func (s *UpstartSuite) TestRemoveStopped(c *gc.C) {
+	s.goodInstall(c)
+	s.StoppedStatus(c)
+	c.Assert(s.service.StopAndRemove(), gc.IsNil)
+	_, err := os.Stat(filepath.Join(s.service.Conf.InitDir, "some-service.conf"))
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *UpstartSuite) TestRemoveRunning(c *gc.C) {
+	s.goodInstall(c)
+	s.RunningStatus(c)
+	s.MakeTool(c, "stop", "exit 99")
+	c.Assert(s.service.StopAndRemove(), gc.ErrorMatches, ".*exit status 99.*")
+	_, err := os.Stat(filepath.Join(s.service.Conf.InitDir, "some-service.conf"))
+	c.Assert(err, jc.ErrorIsNil)
+	s.MakeTool(c, "stop", "exit 0")
+	c.Assert(s.service.StopAndRemove(), gc.IsNil)
+	_, err = os.Stat(filepath.Join(s.service.Conf.InitDir, "some-service.conf"))
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *UpstartSuite) TestStopAndRemove(c *gc.C) {
+	s.goodInstall(c)
+	s.RunningStatus(c)
+	s.MakeTool(c, "stop", "exit 99")
+
+	// StopAndRemove will fail, as it calls stop.
+	c.Assert(s.service.StopAndRemove(), gc.ErrorMatches, ".*exit status 99.*")
+	_, err := os.Stat(filepath.Join(s.service.Conf.InitDir, "some-service.conf"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	// Plain old Remove will succeed.
+	c.Assert(s.service.Remove(), gc.IsNil)
+	_, err = os.Stat(filepath.Join(s.service.Conf.InitDir, "some-service.conf"))
+	c.Assert(err, jc.Satisfies, os.IsNotExist)
+}
+
+func (s *UpstartSuite) TestInstallErrors(c *gc.C) {
+	conf := common.Conf{}
+	check := func(msg string) {
+		c.Assert(s.service.Install(), gc.ErrorMatches, msg)
+		_, err := s.service.InstallCommands()
+		c.Assert(err, gc.ErrorMatches, msg)
+	}
+	s.service.Conf = conf
+	s.service.Name = ""
+	check("missing Name")
+	s.service.Name = "some-service"
+	check("missing InitDir")
+	s.service.Conf.InitDir = c.MkDir()
+	check("missing Desc")
+	s.service.Conf.Desc = "this is an upstart service"
+	check("missing Cmd")
+}
+
+const expectStart = `description "this is an upstart service"
+author "Juju Team <juju@lists.ubuntu.com>"
+start on runlevel [2345]
+stop on runlevel [!2345]
+respawn
+normal exit 0
+`
+
+func (s *UpstartSuite) dummyConf(c *gc.C) common.Conf {
+	return common.Conf{
+		Desc:    "this is an upstart service",
+		Cmd:     "do something",
+		InitDir: s.initDir,
+	}
+}
+
+func (s *UpstartSuite) assertInstall(c *gc.C, conf common.Conf, expectEnd string) {
+	expectContent := expectStart + expectEnd
+	expectPath := filepath.Join(conf.InitDir, "some-service.conf")
+
+	s.service.Conf = conf
+	svc := s.service
+	cmds, err := s.service.InstallCommands()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(cmds, gc.DeepEquals, []string{
+		"cat >> " + expectPath + " << 'EOF'\n" + expectContent + "EOF\n",
+		"start some-service",
+	})
+
+	s.MakeTool(c, "start", "exit 99")
+	err = svc.Install()
+	c.Assert(err, gc.ErrorMatches, ".*exit status 99.*")
+	s.MakeTool(c, "start", "exit 0")
+	err = svc.Install()
+	c.Assert(err, jc.ErrorIsNil)
+	content, err := ioutil.ReadFile(expectPath)
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(string(content), gc.Equals, expectContent)
+}
+
+func (s *UpstartSuite) TestInstallSimple(c *gc.C) {
+	conf := s.dummyConf(c)
+	s.assertInstall(c, conf, "\n\nscript\n\n\n  exec do something\nend script\n")
+}
+
+func (s *UpstartSuite) TestInstallExtraScript(c *gc.C) {
+	conf := s.dummyConf(c)
+	conf.ExtraScript = "extra lines of script"
+	s.assertInstall(c, conf, "\n\nscript\nextra lines of script\n\n  exec do something\nend script\n")
+}
+
+func (s *UpstartSuite) TestInstallOutput(c *gc.C) {
+	conf := s.dummyConf(c)
+	conf.Out = "/some/output/path"
+	s.assertInstall(c, conf, "\n\nscript\n\n\n  # Ensure log files are properly protected\n  touch /some/output/path\n  chown syslog:syslog /some/output/path\n  chmod 0600 /some/output/path\n\n  exec do something >> /some/output/path 2>&1\nend script\n")
+}
+
+func (s *UpstartSuite) TestInstallEnv(c *gc.C) {
+	conf := s.dummyConf(c)
+	conf.Env = map[string]string{"FOO": "bar baz", "QUX": "ping pong"}
+	s.assertInstall(c, conf, `env FOO="bar baz"
+env QUX="ping pong"
+
+
+script
+
+
+  exec do something
+end script
+`)
+}
+
+func (s *UpstartSuite) TestInstallLimit(c *gc.C) {
+	conf := s.dummyConf(c)
+	conf.Limit = map[string]string{"nofile": "65000 65000", "nproc": "20000 20000"}
+	s.assertInstall(c, conf, `
+limit nofile 65000 65000
+limit nproc 20000 20000
+
+script
+
+
+  exec do something
+end script
+`)
+}
+
+func (s *UpstartSuite) TestInstallAlreadyRunning(c *gc.C) {
+	pathTo := func(name string) string {
+		return filepath.Join(s.testPath, name)
+	}
+	s.MakeTool(c, "status-stopped", `echo "some-service stop/waiting"`)
+	s.MakeTool(c, "status-started", `echo "some-service start/running, process 123"`)
+	s.MakeTool(c, "stop", fmt.Sprintf(
+		"rm %s; ln -s %s %s",
+		pathTo("status"), pathTo("status-stopped"), pathTo("status"),
+	))
+	s.MakeTool(c, "start", fmt.Sprintf(
+		"rm %s; ln -s %s %s",
+		pathTo("status"), pathTo("status-started"), pathTo("status"),
+	))
+	err := symlink.New(pathTo("status-started"), pathTo("status"))
+	c.Assert(err, jc.ErrorIsNil)
+
+	conf := s.dummyConf(c)
+	s.service.UpdateConfig(conf)
+	err = s.service.Install()
+	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(s.service, jc.Satisfies, (*upstart.Service).Running)
+}


### PR DESCRIPTION
The tests still depend on juju-core, but that's not nearly so limiting.