### PR TITLE
hook: do not error when SetStatus is used in older juju versions

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -318,9 +318,14 @@ const (
 )
 
 // SetStatus sets the current status of a charm and an associated
-// message.
+// message. If the status cannot be set because we are
+// using a version of juju that does not yet support it,
+// that error will be silently discarded.
 func (ctxt *Context) SetStatus(st Status, message string) error {
 	_, err := ctxt.Runner.Run("status-set", string(st), message)
+	if errgo.Cause(err) == ErrUnimplemented {
+		return nil
+	}
 	return errgo.Mask(err)
 }
 

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -701,6 +701,14 @@ func (s *HookSuite) TestRegisterContextTwice(c *gc.C) {
 	}, gc.PanicMatches, `RegisterContext called more than once`)
 }
 
+func (s *HookSuite) TestRunUnimplementedCommand(c *gc.C) {
+	s.StartServer(c, 0, "peer0/0")
+	ctxt := s.newContext(c, "config-changed")
+	defer ctxt.Close()
+	_, err := ctxt.Runner.Run("unimplemented-command")
+	c.Assert(errgo.Cause(err), gc.Equals, hook.ErrUnimplemented)
+}
+
 func (s *HookSuite) TestCommandCall(c *gc.C) {
 	s.StartServer(c, 0, "peer0/0")
 


### PR DESCRIPTION
This means we can write charms that use SetStatus without worrying
about whether it is actually implemented.