### PR TITLE
cmd/gocharm: use charm.v5 in inspect code

### DIFF
--- a/cmd/gocharm/inspect.go
+++ b/cmd/gocharm/inspect.go
@@ -59,7 +59,7 @@ package main
 
 import (
 	"encoding/json"
-	"gopkg.in/juju/charm.v4"
+	"gopkg.in/juju/charm.v5"
 	"os"
 
 	inspect {{.CharmPackage | printf "%q"}}


### PR DESCRIPTION
Missed because govers doesn't look inside comments.