### PR TITLE
hook: allow JUJU_REMOTE_UNIT to be omitted in relation-broken hook

### DIFF
--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -85,10 +85,7 @@ func (s *HookSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *HookSuite) TearDownTest(c *gc.C) {
-	for key, val := range s.savedVars {
-		os.Setenv(key, val)
-		delete(s.savedVars, key)
-	}
+	s.resetEnv(c)
 	if s.server != nil {
 		s.server.Close()
 		c.Assert(<-s.err, gc.IsNil)
@@ -96,6 +93,13 @@ func (s *HookSuite) TearDownTest(c *gc.C) {
 	}
 	os.Args = s.savedArgs
 	*hook.HookStateDir = s.savedHookStateDir
+}
+
+func (s *HookSuite) resetEnv(c *gc.C) {
+	for key, val := range s.savedVars {
+		os.Setenv(key, val)
+		delete(s.savedVars, key)
+	}
 }
 
 func (s *HookSuite) setenv(key, val string) {
@@ -658,7 +662,7 @@ func (errorState) Save(name string, data []byte) error {
 	return errgo.New("save error")
 }
 
-func (s *HookSuite) TestContextFromEnvironmentUsage(c *gc.C) {
+func (s *HookSuite) TestNewContextFromEnvironmentUsage(c *gc.C) {
 	r := hook.NewRegistry()
 	r.RegisterCommand(func([]string) {})
 	r.Clone("client").RegisterCommand(func([]string) {})

--- a/hook/main.go
+++ b/hook/main.go
@@ -32,7 +32,8 @@ var mustEnvVars = []string{
 var relationEnvVars = []string{
 	envRelationName,
 	envRelationId,
-	envRemoteUnit,
+	// Note that envRemoteUnit is not guaranteed
+	// to be set for relation-broken hooks.
 }
 
 // Main creates a new context from the environment and invokes the
@@ -186,6 +187,9 @@ func NewContextFromEnvironment(r *Registry) (*Context, PersistentState, error) {
 	vars := mustEnvVars
 	if os.Getenv(envRelationName) != "" {
 		vars = append(vars, relationEnvVars...)
+		if !strings.HasSuffix(hookName, "-relation-broken") {
+			vars = append(vars, envRemoteUnit)
+		}
 	}
 	for _, v := range vars {
 		if os.Getenv(v) == "" {


### PR DESCRIPTION
With thanks to Vasiliy Tolstov for reporting the bug.