### PR TITLE
charmbits/httpservice: dependency injection

### DIFF
--- a/charmbits/httpservice/export_test.go
+++ b/charmbits/httpservice/export_test.go
@@ -1,0 +1,17 @@
+package httpservice
+
+import (
+	"reflect"
+)
+
+func ClearRegisteredRelations() {
+	registeredRelations = make(map[reflect.Type]*registeredRelation)
+}
+
+func RegisteredRelationInfo(t reflect.Type) (T, D reflect.Type, ok bool) {
+	reg, ok := registeredRelations[t]
+	if !ok {
+		return nil, nil, false
+	}
+	return reg.t, reg.d, true
+}

--- a/charmbits/httpservice/httpservice_test.go
+++ b/charmbits/httpservice/httpservice_test.go
@@ -1,0 +1,329 @@
+package httpservice_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"time"
+
+	jujutesting "github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/juju/charm.v5"
+
+	"github.com/juju/gocharm/charmbits/httpservice"
+	"github.com/juju/gocharm/charmbits/service"
+	"github.com/juju/gocharm/charmbits/simplerelation"
+	"github.com/juju/gocharm/hook"
+	"github.com/juju/gocharm/hook/hooktest"
+)
+
+type suite struct{}
+
+var _ = gc.Suite(&suite{})
+
+func (s *suite) SetUpTest(c *gc.C) {
+	httpservice.ClearRegisteredRelations()
+}
+
+func nopRegisterField(r *hook.Registry, tag string) (getVal func() (interface{}, error)) {
+	panic("should not be called")
+}
+
+var registerRelationTests = []struct {
+	about         string
+	setFieldValue interface{}
+	expectPanic   string
+	expectT       reflect.Type
+	expectD       reflect.Type
+}{{
+	about:         "correctly specified function",
+	setFieldValue: func(*string, int) error { return nil },
+	expectT:       reflect.TypeOf(""),
+	expectD:       reflect.TypeOf(0),
+}, {
+	about:         "non-function setFieldValue",
+	setFieldValue: 0,
+	expectPanic:   `setFieldValue function argument to RegisterRelationType is int not func`,
+}, {
+	about:         "too few return values",
+	setFieldValue: func(*struct{}, int) {},
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong return count, got 0, want 1`,
+}, {
+	about:         "too many return values",
+	setFieldValue: func(*struct{}, int) (int, error) { panic("unreachable") },
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong return count, got 2, want 1`,
+}, {
+	about:         "non-error return type",
+	setFieldValue: func(*struct{}, int) int { panic("unreachable") },
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong return type, got int, want error`,
+}, {
+	about:         "too few args",
+	setFieldValue: func(*struct{}) error { panic("unreachable") },
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong argument count; got 1, want 2`,
+}, {
+	about:         "too many args",
+	setFieldValue: func(*struct{}, int, int) error { panic("unreachable") },
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong argument count; got 3, want 2`,
+}, {
+	about:         "first arg not pointer",
+	setFieldValue: func(struct{}, int) error { panic("unreachable") },
+	expectPanic:   `setFieldValue function argument to RegisterRelationType has wrong first argument type; got struct {} want pointer`,
+}}
+
+func (s *suite) TestRegisterRelation(c *gc.C) {
+	for i, test := range registerRelationTests {
+		c.Logf("test %d: %s", i, test.about)
+		httpservice.ClearRegisteredRelations()
+		if test.expectPanic != "" {
+			c.Assert(func() {
+				httpservice.RegisterRelationType(nopRegisterField, test.setFieldValue)
+			}, gc.PanicMatches, "cannot register relation: "+test.expectPanic)
+			continue
+		}
+		httpservice.RegisterRelationType(nopRegisterField, test.setFieldValue)
+		t, d, ok := httpservice.RegisteredRelationInfo(test.expectT)
+		c.Assert(ok, gc.Equals, true)
+		c.Assert(t, gc.Equals, test.expectT)
+		c.Assert(d, gc.Equals, test.expectD)
+	}
+}
+
+var registerTests = []struct {
+	about            string
+	registerField    func(r *hook.Registry, tag string) (getVal func() (interface{}, error))
+	setFieldValue    interface{}
+	serviceName      string
+	httpRelationName string
+	handler          interface{}
+	expectRelations  map[string]charm.Relation
+}{{
+	about: "no panic, simple relation",
+	registerField: func(r *hook.Registry, tag string) func() (interface{}, error) {
+		if tag != "foo-tag" {
+			panic("unexpected tag " + tag)
+		}
+		r.RegisterRelation(charm.Relation{
+			Name:      "foo",
+			Interface: "foo-interface",
+			Role:      charm.RoleRequirer,
+			Scope:     charm.ScopeGlobal,
+		})
+		return func() (interface{}, error) {
+			panic("unreachable")
+		}
+	},
+	setFieldValue: func(f *string, v string) error {
+		*f = "relation val: " + v
+		return nil
+	},
+	serviceName:      "fooservice",
+	httpRelationName: "httpserver",
+	handler: func(s string, r *struct {
+		Foo string `httpservice:"foo-tag"`
+	}) (httpservice.Handler, error) {
+		return nil, fmt.Errorf("no handler yet")
+	},
+	expectRelations: map[string]charm.Relation{
+		"foo": {
+			Name:      "foo",
+			Role:      charm.RoleRequirer,
+			Interface: "foo-interface",
+			Limit:     1,
+			Scope:     charm.ScopeGlobal,
+		},
+		"httpserver": {
+			Name:      "httpserver",
+			Role:      charm.RoleProvider,
+			Interface: "http",
+			Scope:     charm.ScopeGlobal,
+		},
+	},
+},
+
+// TODO test all error cases in newHandlerInfo
+}
+
+func (s *suite) TestRegister(c *gc.C) {
+	for i, test := range registerTests {
+		c.Logf("test %d: %s", i, test.about)
+		httpservice.ClearRegisteredRelations()
+		httpservice.RegisterRelationType(test.registerField, test.setFieldValue)
+		r := hook.NewRegistry()
+		var svc httpservice.Service
+		svc.Register(r, test.serviceName, test.httpRelationName, test.handler)
+		c.Assert(r.RegisteredRelations(), jc.DeepEquals, test.expectRelations)
+	}
+}
+
+type testType struct {
+	relValues map[hook.UnitId]map[string]string
+}
+
+type testArg struct {
+	Arg string
+}
+
+func (s *suite) TestServer(c *gc.C) {
+	// First register the relation type. This would usually be
+	// done at init time.
+	registerField := func(r *hook.Registry, tag string) func() (interface{}, error) {
+		c.Logf("registering field with tag %q", tag)
+		var rel simplerelation.Requirer
+		rel.Register(r.Clone("rel"), "foorelation", "foo-interface")
+
+		return func() (interface{}, error) {
+			c.Logf("getting relation data (len vals %d)", len(rel.Values()))
+			if vals := rel.Values(); len(vals) > 0 {
+				return vals, nil
+			}
+			c.Logf("returning ErrRelationIncomplete because there are no relations")
+			// No relations - no handler.
+			return nil, httpservice.ErrRelationIncomplete
+		}
+	}
+	setFieldValue := func(fieldVal *testType, vals map[hook.UnitId]map[string]string) error {
+		c.Logf("setFieldVal %v", vals)
+		if fieldVal.relValues != nil {
+			return httpservice.ErrRestartNeeded
+		}
+		fieldVal.relValues = vals
+		return nil
+	}
+	httpservice.RegisterRelationType(registerField, setFieldValue)
+
+	closeNotify := make(chan struct{}, 1)
+	// Now create a test runner to actually test the logic.
+	runner := &hooktest.Runner{
+		HookStateDir: c.MkDir(),
+		RegisterHooks: func(r *hook.Registry) {
+			var svc httpservice.Service
+			type relations struct {
+				Test testType
+			}
+			svc.Register(r.Clone("svc"), "httpservicename", "http", func(arg testArg, rel *relations) (httpservice.Handler, error) {
+				c.Logf("starting test handler")
+				return &testHandler{
+					closeNotify: closeNotify,
+					arg:         arg.Arg,
+					relValues:   rel.Test.relValues,
+				}, nil
+			})
+			r.RegisterHook("start", func() error {
+				return svc.Start(testArg{
+					Arg: "start arg",
+				})
+			})
+			r.RegisterHook("stop", func() error {
+				return svc.Stop()
+			})
+		},
+		Logger: c,
+	}
+
+	notify := make(chan hooktest.ServiceEvent, 10)
+	service.NewService = hooktest.NewServiceFunc(runner, notify)
+
+	err := runner.RunHook("install", "", "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(runner.Record, gc.HasLen, 0)
+
+	err = runner.RunHook("start", "", "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(runner.Record, gc.HasLen, 0)
+
+	httpPort := jujutesting.FindTCPPort()
+	runner.Config = map[string]interface{}{
+		"http-port": httpPort,
+	}
+	err = runner.RunHook("config-changed", "", "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(runner.Record, gc.DeepEquals, [][]string{
+		{"open-port", fmt.Sprintf("%d/tcp", httpPort)},
+	})
+	runner.Record = nil
+
+	e := expectEvent(c, notify, hooktest.ServiceEventInstall)
+	c.Assert(e.Params.Name, gc.Equals, "httpservicename")
+	e = expectEvent(c, notify, hooktest.ServiceEventStart)
+	c.Assert(e.Params.Name, gc.Equals, "httpservicename")
+
+	runner.Relations = map[hook.RelationId]map[hook.UnitId]map[string]string{
+		"rel0": {
+			"fooservice/0": {
+				"foo": "bar",
+			},
+		},
+	}
+	runner.RelationIds = map[string][]hook.RelationId{
+		"foorelation": {"rel0"},
+	}
+	err = runner.RunHook("foorelation-relation-joined", "rel0", "fooservice/0")
+	c.Assert(err, gc.IsNil)
+	c.Assert(runner.Record, gc.HasLen, 0)
+
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", httpPort))
+	c.Assert(err, gc.IsNil)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, gc.IsNil)
+	var tresp testResponse
+	err = json.Unmarshal(data, &tresp)
+	c.Assert(err, gc.IsNil, gc.Commentf("data: %q", data))
+	c.Assert(tresp, jc.DeepEquals, testResponse{
+		Arg: "start arg",
+		RelValues: map[hook.UnitId]map[string]string{
+			"fooservice/0": {
+				"foo": "bar",
+			},
+		},
+	})
+
+	err = runner.RunHook("stop", "", "")
+	c.Assert(err, gc.IsNil)
+	c.Assert(runner.Record, gc.HasLen, 0)
+
+	select {
+	case <-closeNotify:
+	case <-time.After(time.Second):
+		c.Fatalf("timed out waiting for close notification")
+	}
+}
+
+type testHandler struct {
+	closeNotify chan struct{}
+	arg         string
+	relValues   map[hook.UnitId]map[string]string
+}
+
+type testResponse struct {
+	Arg       string
+	RelValues map[hook.UnitId]map[string]string
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if err := json.NewEncoder(w).Encode(testResponse{
+		Arg:       h.arg,
+		RelValues: h.relValues,
+	}); err != nil {
+		panic(err)
+	}
+}
+
+func (h *testHandler) Close() error {
+	h.closeNotify <- struct{}{}
+	return nil
+}
+
+func expectEvent(c *gc.C, eventc <-chan hooktest.ServiceEvent, kind hooktest.ServiceEventKind) hooktest.ServiceEvent {
+	select {
+	case e := <-eventc:
+		c.Assert(e.Kind, gc.Equals, kind, gc.Commentf("got event %#v", e))
+		return e
+	case <-time.After(5 * time.Second):
+		c.Fatalf("no event received; expected %v", kind)
+		panic("unreachable")
+	}
+}

--- a/charmbits/httpservice/package_test.go
+++ b/charmbits/httpservice/package_test.go
@@ -1,0 +1,11 @@
+package httpservice_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/charmbits/httpservice/server.go
+++ b/charmbits/httpservice/server.go
@@ -1,0 +1,440 @@
+package httpservice
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"sync"
+	"time"
+
+	"gopkg.in/errgo.v1"
+	"gopkg.in/tomb.v2"
+
+	"github.com/juju/gocharm/charmbits/service"
+	"github.com/juju/gocharm/hook"
+)
+
+// server represents a running HTTP server.
+type server struct {
+	tomb tomb.Tomb
+
+	handlerInfo *handlerInfo
+	handler     Handler
+	stateDir    string
+
+	mu    sync.Mutex
+	state ServerState
+	// relationState holds the struct value with fields
+	// set by the setFieldValue argument to RegisterRelation
+	// calls.
+	relationState reflect.Value
+	httpListener  *handlerListener
+	httpsListener *handlerListener
+}
+
+// ServerState holds the state of a server - all the
+// parameters that might affect it.
+//
+// It is an implementation detail and only exposed
+// because net/rpc requires it.
+type ServerState struct {
+	HTTPPort  int
+	HTTPSPort int
+	CertPEM   string
+
+	// Arg holds the value passed to Service.Start, marshaled as JSON.
+	ArgData []byte
+
+	// RelationValues holds an entry for each relation
+	// defined in the second argument of the handler function
+	// passed to Register.
+	RelationValues map[string][]byte
+}
+
+// startServer starts the actual HTTP server running. It is called
+// in service context, not hook context.
+func startServer(ctxt *service.Context, args []string, h *handlerInfo) (hook.Command, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("need exactly one argument, got %q", args)
+	}
+	srv := &server{
+		handlerInfo: h,
+		stateDir:    args[0],
+	}
+	state, err := srv.loadState()
+	if err != nil {
+		return nil, fmt.Errorf("cannot load state: %v", err)
+	}
+	var fb Feedback
+	srv.set(state, &fb)
+	fb.show()
+	// Fool net/rpc into thinking the type is exported, because
+	// we don't want to export the srv type from this package.
+	type Srv struct {
+		*server
+	}
+	rpcCmd, err := ctxt.ServeLocalRPC(Srv{srv})
+	if err != nil {
+		return nil, errgo.Notef(err, "serve local RPC failed")
+	}
+	srv.tomb.Go(func() error {
+		srv.tomb.Kill(rpcCmd.Wait())
+		return nil
+	})
+	srv.tomb.Go(func() error {
+		<-srv.tomb.Dying()
+		// The command has been killed. Stop the RPC listener
+		// and close any current listeners to cause the handlers
+		// to terminate.
+		rpcCmd.Kill()
+		err := rpcCmd.Wait()
+		if err != nil {
+			err = errgo.Notef(err, "local RPC server")
+		}
+
+		srv.mu.Lock()
+		defer srv.mu.Unlock()
+		srv.closeResources()
+		return err
+	})
+	return srv, nil
+}
+
+// Kill implements gocharm.Command.Kill.
+func (srv *server) Kill() {
+	srv.tomb.Kill(nil)
+}
+
+// Wait implements gocharm.Command.Wait.
+func (srv *server) Wait() error {
+	return srv.tomb.Wait()
+}
+
+// Feedback is an implementation detail, exposed only because net/rpc requires it.
+type Feedback struct {
+	Warnings []string
+}
+
+// show shows all the warnings.
+func (fb *Feedback) show() {
+	for _, w := range fb.Warnings {
+		fmt.Fprintf(os.Stderr, "warning: %v\n", w)
+	}
+}
+
+// addError adds the given error to the list of warnings
+// that will be reported as the result of an RPC call.
+func (fb *Feedback) addError(err error) {
+	fb.Warnings = append(fb.Warnings, err.Error())
+}
+
+// Set implements an RPC server method that is called
+// to set the current server state. Instead of returning
+// an error, any errors are recorded in the given response
+// value
+func (srv *server) Set(p *ServerState, response *Feedback) error {
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.set(*p, response)
+	response.show()
+	srv.state = *p
+	// Save the server state so that if it's started or the
+	// instance is rebooted, we can carry on as before.
+	if err := srv.saveState(srv.state); err != nil {
+		return errgo.Notef(err, "cannot save server state")
+	}
+	return nil
+}
+
+func (srv *server) serveHTTP(port int, h http.Handler) (*handlerListener, error) {
+	addr := ":" + strconv.Itoa(port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, errgo.Newf("cannot listen on %s: %v", addr, err)
+	}
+	server := &http.Server{
+		Addr:    addr,
+		Handler: h,
+	}
+	return newHandlerListener(server, listener), nil
+}
+
+func (srv *server) serveHTTPS(port int, certPEM string, h http.Handler) (*handlerListener, error) {
+	certPEMBytes := []byte(certPEM)
+	cert, err := tls.X509KeyPair(certPEMBytes, certPEMBytes)
+	if err != nil {
+		return nil, errgo.Newf("cannot parse certificate: %v", err)
+	}
+	config := &tls.Config{
+		NextProtos:   []string{"http/1.1"},
+		Certificates: []tls.Certificate{cert},
+	}
+	addr := ":" + strconv.Itoa(port)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, errgo.Newf("cannot listen on %s: %v", addr, err)
+	}
+	tlsListener := tls.NewListener(
+		tcpKeepAliveListener{listener.(*net.TCPListener)},
+		config,
+	)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: h,
+	}
+	return newHandlerListener(server, tlsListener), nil
+}
+
+// set sets the current state of the server, and starts
+// or restarts the HTTP listener when appropriate.
+func (srv *server) set(state ServerState, fb *Feedback) {
+	restartNeeded := false
+	noStart := false
+	if err := srv.setRelations(state); err != nil {
+		switch cause := errgo.Cause(err); cause {
+		case ErrRestartNeeded:
+			restartNeeded = true
+		case ErrRelationIncomplete:
+			restartNeeded = true
+			fb.addError(err)
+			noStart = true
+		default:
+			fb.addError(err)
+			noStart = true
+		}
+	}
+	restartNeeded = restartNeeded || srv.needsRestart(state)
+	log.Printf("srv set state %#v; current state %#v", state, srv.state)
+	if restartNeeded {
+		srv.closeResources()
+	}
+	if noStart {
+		return
+	}
+	httpOK := state.HTTPPort != 0
+	httpsOK := state.HTTPSPort != 0 && state.CertPEM != ""
+	h, err := srv.handlerInfo.handler(state.ArgData, srv.relationState)
+	if err != nil {
+		fb.addError(errgo.Notef(err, "cannot get handler"))
+		return
+	}
+	if srv.httpListener == nil && httpOK {
+		log.Printf("starting HTTP server on port %v", state.HTTPPort)
+		srv.httpListener, err = srv.serveHTTP(state.HTTPPort, h)
+		if err != nil {
+			fb.addError(errgo.Notef(err, "cannot start HTTP server"))
+		}
+	}
+	if srv.httpsListener == nil && httpsOK {
+		log.Printf("starting HTTPS server on port %v", state.HTTPSPort)
+		srv.httpsListener, err = srv.serveHTTPS(state.HTTPSPort, state.CertPEM, h)
+		if err != nil {
+			fb.addError(errgo.Notef(err, "cannot start HTTPS server"))
+		}
+	}
+	srv.handler = h
+	srv.state = state
+	return
+}
+
+type handlerListener struct {
+	tomb tomb.Tomb
+	lis  net.Listener
+}
+
+func newHandlerListener(server *http.Server, lis net.Listener) *handlerListener {
+	hl := &handlerListener{
+		lis: lis,
+	}
+	hl.tomb.Go(func() error {
+		if err := server.Serve(lis); err != nil {
+			return errgo.Notef(err, "listener on %s died", lis.Addr())
+		}
+		return nil
+	})
+	return hl
+}
+
+func (hl *handlerListener) Kill() {
+	hl.lis.Close()
+}
+
+func (hl *handlerListener) Wait() error {
+	hl.tomb.Wait()
+	return nil
+}
+
+// needsRestart reports whether the server
+// needs a restart when the state is changed to the given
+// state.
+func (srv *server) needsRestart(state ServerState) bool {
+	// Note that when the mongodb addresses change, that
+	// doesn't necessarily imply we'll need a restart,
+	// as mongodb informs all clients of the new addresses
+	// as a matter of course. We'll store the addresses however,
+	// and they'll be used when reconnecting.
+	return state.HTTPPort == 0 ||
+		state.HTTPPort != srv.state.HTTPPort ||
+		state.HTTPSPort != srv.state.HTTPSPort ||
+		state.CertPEM != srv.state.CertPEM ||
+		!bytes.Equal(state.ArgData, srv.state.ArgData)
+}
+
+// setRelations sets the relation fields from the information in the
+// given state. If it returns ErrRestartNeeded, the handler
+// must be restarted.
+func (srv *server) setRelations(state ServerState) error {
+	h := srv.handlerInfo
+	if h.relationType == nil {
+		return nil
+	}
+	if !srv.relationState.IsValid() {
+		srv.relationState = reflect.New(h.relationType).Elem()
+	}
+
+	// First check that we have all our required relations
+	incomplete := false
+	for i := 0; i < h.relationType.NumField(); i++ {
+		f := h.relationType.Field(i)
+		data := state.RelationValues[f.Name]
+		// If there's no data, it indicates that the relation is incomplete.
+		if len(data) == 0 {
+			incomplete = true
+		}
+	}
+	if incomplete {
+		return ErrRelationIncomplete
+	}
+
+	// For each field, unmarshal the relation data into the
+	// expected type and call the appropriate setFieldFunc value.
+	restartNeeded := false
+	for i := 0; i < h.relationType.NumField(); i++ {
+		f := h.relationType.Field(i)
+		// TODO we could potentially do all these in parallel
+		// so that any network connections they might be
+		// making would be concurrent.
+		if err := srv.setFieldValue(f, state); err != nil {
+			if errgo.Cause(err) == ErrRestartNeeded {
+				restartNeeded = true
+			} else {
+				return errgo.Notef(err, "cannot set field %s", f.Name)
+			}
+		}
+	}
+	if restartNeeded {
+		return ErrRestartNeeded
+	}
+	return nil
+}
+
+// setFieldValue sets the value of the given struct field from the
+// relation data for that field held in state.RelationValues.
+func (srv *server) setFieldValue(f reflect.StructField, state ServerState) error {
+	registeredRelationsMutex.Lock()
+	reg := registeredRelations[f.Type]
+	registeredRelationsMutex.Unlock()
+	if reg == nil {
+		// This shouldn't be able to happen because we should have
+		// checked that all fields have registered types during Register.
+		panic(errgo.Newf("no registered relation for type %s in field %s", f.Type, f.Name))
+	}
+	args := []reflect.Value{
+		srv.relationState.Field(0).Addr(),
+		reflect.New(reg.d),
+	}
+
+	// Unmarshal the data into the newly created  instance of type D.
+	data := state.RelationValues[f.Name]
+	if err := json.Unmarshal(data, args[1].Interface()); err != nil {
+		return errgo.Notef(err, "cannot unmarshal relation data (type %v, data %q)", args[1].Type(), data)
+	}
+	args[1] = args[1].Elem()
+	err, _ := reg.setFieldValue.Call(args)[0].Interface().(error)
+	if err != nil {
+		return errgo.Mask(err, errgo.Is(ErrRestartNeeded))
+	}
+	return nil
+}
+
+// closeResources closes any current listeners. Called
+// with srv.mu held.
+func (srv *server) closeResources() {
+	if srv.handler != nil {
+		srv.handler.Close()
+		srv.handler = nil
+	}
+	if srv.httpListener != nil {
+		srv.httpListener.Kill()
+		srv.httpListener.Wait()
+		srv.httpListener = nil
+	}
+	if srv.httpsListener != nil {
+		srv.httpsListener.Kill()
+		srv.httpsListener.Wait()
+		srv.httpsListener = nil
+	}
+}
+
+func (srv *server) saveState(state ServerState) error {
+	data, err := json.Marshal(state)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	path := srv.statePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errgo.Mask(err)
+	}
+	if err := ioutil.WriteFile(path, data, 0600); err != nil {
+		return errgo.Mask(err)
+	}
+	return nil
+}
+
+func (srv *server) loadState() (ServerState, error) {
+	data, err := ioutil.ReadFile(srv.statePath())
+	if os.IsNotExist(err) {
+		return ServerState{}, nil
+	}
+	if err != nil {
+		return ServerState{}, errgo.Mask(err)
+	}
+	var state ServerState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return ServerState{}, errgo.Notef(err, "cannot unmarshal state %q", data)
+	}
+	return state, nil
+}
+
+func (srv *server) statePath() string {
+	return filepath.Join(srv.stateDir, "serverstate.json")
+}
+
+// tcpKeepAliveListener is stolen from net/http
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}

--- a/charmbits/mongodbrelation/package_test.go
+++ b/charmbits/mongodbrelation/package_test.go
@@ -1,0 +1,11 @@
+package mongodbrelation_test
+
+import (
+	"testing"
+
+	jujutesting "github.com/juju/testing"
+)
+
+func TestPackage(t *testing.T) {
+	jujutesting.MgoTestPackage(t, nil)
+}

--- a/charmbits/mongodbrelation/requirer.go
+++ b/charmbits/mongodbrelation/requirer.go
@@ -1,4 +1,26 @@
 // The mongodbrelation package implements a Juju mongodb relation.
+//
+// Importing this package also registers the type
+// *mgo.Session with the httpservice package,
+// so that it can be used as a relation field with httpservice.Service.Register.
+//
+// For example, to register a web service that requires a MongoDB connection,
+// you might do something like this:
+//
+//	type relations struct {
+//		Session *mgo.Session	`httpservice:"mongodb"`
+//	}
+//	func RegisterHooks(r *hook.Registry) {
+// 		var svc httpservice.Service
+//		svc.Register(r, "somename", "http", func(_ struct{}, rel *relations) (httpservice.Handler, error) {
+//			// rel.Session contains the actual MongoDB connection.
+//			return newHandler(rel)
+//		})
+//	}
+//
+// This would create a Juju requirer relation named "mongodb"
+// and dial the related MongoDB instance before creating
+// the HTTP handler.
 package mongodbrelation
 
 import (
@@ -6,7 +28,9 @@ import (
 	"strings"
 
 	"gopkg.in/errgo.v1"
+	"gopkg.in/mgo.v2"
 
+	"github.com/juju/gocharm/charmbits/httpservice"
 	"github.com/juju/gocharm/charmbits/simplerelation"
 	"github.com/juju/gocharm/hook"
 )
@@ -52,4 +76,46 @@ func unitAddress(vals map[string]string) (string, error) {
 		return "", errgo.Newf("mongodb host %q found with no port", host)
 	}
 	return net.JoinHostPort(host, port), nil
+}
+
+func init() {
+	httpservice.RegisterRelationType(
+		registerField,
+		setFieldValue,
+	)
+}
+
+type relationInfo struct {
+	URL string
+}
+
+func registerField(r *hook.Registry, tag string) func() (interface{}, error) {
+	var req Requirer
+	f := strings.Split(tag, ",")
+	relationName := "mongodb"
+	if f[0] != "" {
+		relationName = f[0]
+	}
+	// get "required" value from tag too?
+	req.Register(r, relationName)
+	return func() (interface{}, error) {
+		if url := req.URL(); url != "" {
+			return relationInfo{
+				URL: req.URL(),
+			}, nil
+		}
+		return nil, httpservice.ErrRelationIncomplete
+	}
+}
+
+func setFieldValue(f **mgo.Session, info relationInfo) error {
+	if *f != nil {
+		return httpservice.ErrRestartNeeded
+	}
+	session, err := mgo.Dial(info.URL)
+	if err != nil {
+		return errgo.Notef(err, "cannot dial mongo at %q", info.URL)
+	}
+	*f = session
+	return nil
 }

--- a/charmbits/mongodbrelation/requirer_test.go
+++ b/charmbits/mongodbrelation/requirer_test.go
@@ -1,0 +1,124 @@
+package mongodbrelation_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	jujutesting "github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/mgo.v2"
+
+	"github.com/juju/gocharm/charmbits/httpservice"
+	_ "github.com/juju/gocharm/charmbits/mongodbrelation"
+	"github.com/juju/gocharm/charmbits/service"
+	"github.com/juju/gocharm/hook"
+	"github.com/juju/gocharm/hook/hooktest"
+)
+
+type suite struct {
+	jujutesting.MgoSuite
+}
+
+var _ = gc.Suite(&suite{})
+
+func (*suite) TestHTTPService(c *gc.C) {
+	// Now create a test runner to actually test the logic.
+	runner := &hooktest.Runner{
+		HookStateDir: c.MkDir(),
+		RegisterHooks: func(r *hook.Registry) {
+			var svc httpservice.Service
+			type relations struct {
+				Session *mgo.Session `httpservice:"mymongo"`
+			}
+			svc.Register(r.Clone("svc"), "httpservicename", "http", func(_ struct{}, rel *relations) (httpservice.Handler, error) {
+				c.Logf("starting test handler")
+				return &testHandler{
+					session: rel.Session,
+				}, nil
+			})
+			r.RegisterHook("start", func() error {
+				return svc.Start(struct{}{})
+			})
+			r.RegisterHook("stop", func() error {
+				return svc.Stop()
+			})
+		},
+		Logger: c,
+	}
+	service.NewService = hooktest.NewServiceFunc(runner, nil)
+
+	// Put a record into the database.
+	session := jujutesting.MgoServer.MustDial()
+	defer session.Close()
+	const dbVal = "something stored in the database"
+	err := testCollection(session).Insert(&mdoc{
+		Val: dbVal,
+	})
+	c.Assert(err, gc.IsNil)
+
+	err = runner.RunHook("install", "", "")
+	c.Assert(err, gc.IsNil)
+
+	err = runner.RunHook("start", "", "")
+	c.Assert(err, gc.IsNil)
+
+	httpPort := jujutesting.FindTCPPort()
+	runner.Config = map[string]interface{}{
+		"http-port": httpPort,
+	}
+	err = runner.RunHook("config-changed", "", "")
+	c.Assert(err, gc.IsNil)
+
+	runner.Relations = map[hook.RelationId]map[hook.UnitId]map[string]string{
+		"rel0": {
+			"somemongodbservice/0": {
+				"hostname": "localhost",
+				"port":     fmt.Sprint(jujutesting.MgoServer.Port()),
+			},
+		},
+	}
+	runner.RelationIds = map[string][]hook.RelationId{
+		"mymongo": {"rel0"},
+	}
+	err = runner.RunHook("mymongo-relation-joined", "rel0", "fooservice/0")
+	c.Assert(err, gc.IsNil)
+
+	// Check that the HTTP server is up and running and has access to
+	// the database.
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/", httpPort))
+	c.Assert(err, gc.IsNil)
+	defer resp.Body.Close()
+	data, err := ioutil.ReadAll(resp.Body)
+	c.Assert(err, gc.IsNil)
+	c.Assert(string(data), gc.Equals, dbVal)
+
+	err = runner.RunHook("stop", "", "")
+	c.Assert(err, gc.IsNil)
+}
+
+func testCollection(s *mgo.Session) *mgo.Collection {
+	return s.DB("db").C("c")
+}
+
+type mdoc struct {
+	Val string
+}
+
+type testHandler struct {
+	session *mgo.Session
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	var doc mdoc
+	err := testCollection(h.session).Find(nil).One(&doc)
+	if err != nil {
+		panic(err)
+	}
+	w.Write([]byte(doc.Val))
+}
+
+func (h *testHandler) Close() error {
+	h.session.Close()
+	return nil
+}

--- a/charmbits/service/service_test.go
+++ b/charmbits/service/service_test.go
@@ -16,7 +16,6 @@ type suite struct{}
 var _ = gc.Suite(&suite{})
 
 func (*suite) TestService(c *gc.C) {
-	var svc service.Service
 
 	startCount := 0
 	configChangedCount := 0
@@ -28,6 +27,7 @@ func (*suite) TestService(c *gc.C) {
 	r := &hooktest.Runner{
 		HookStateDir: c.MkDir(),
 		RegisterHooks: func(r *hook.Registry) {
+			var svc service.Service
 			svc.Register(r.Clone("svc"), "servicename", startService)
 			var ctxt *hook.Context
 			r.RegisterContext(func(hctxt *hook.Context) error {

--- a/cmd/gocharm/main.go
+++ b/cmd/gocharm/main.go
@@ -79,6 +79,7 @@ var (
 	verbose = flag.Bool("v", false, "print information about charms being built")
 	source  = flag.Bool("source", false, "include source code instead of binary executable")
 	godeps  = flag.Bool("godeps", false, "include godeps output in $CHARM_DIR/dependencies.tsv")
+	keep    = flag.Bool("keep", false, "do not delete temporary files")
 )
 
 // TODO select current OS version by default
@@ -147,7 +148,9 @@ func main1(pkgPath string) error {
 	if err != nil {
 		return errgo.Notef(err, "cannot make temporary directory")
 	}
-	defer os.RemoveAll(tempDir)
+	if !*keep {
+		defer os.RemoveAll(tempDir)
+	}
 
 	tempCharmDir := filepath.Join(tempDir, "charm")
 	if err := copyContents(pkg, tempCharmDir); err != nil {

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -302,7 +302,7 @@ func (ctxt *Context) GetConfigString(key string) (string, error) {
 	return val, nil
 }
 
-// GetConfigString returns the charm configuration value for the given
+// GetConfigInt returns the charm configuration value for the given
 // key as an int. It returns zero if the value has not been
 // set.
 func (ctxt *Context) GetConfigInt(key string) (int, error) {
@@ -313,7 +313,7 @@ func (ctxt *Context) GetConfigInt(key string) (int, error) {
 	return val, nil
 }
 
-// GetConfigString returns the charm configuration value for the given
+// GetConfigFloat64 returns the charm configuration value for the given
 // key as a float64. It returns zero if the value has not been
 // set.
 func (ctxt *Context) GetConfigFloat64(key string) (float64, error) {
@@ -324,7 +324,7 @@ func (ctxt *Context) GetConfigFloat64(key string) (float64, error) {
 	return val, nil
 }
 
-// GetConfigString returns the charm configuration value for the given
+// GetConfigBool returns the charm configuration value for the given
 // key as a bool. It returns false if the value has not been
 // set.
 func (ctxt *Context) GetConfigBool(key string) (bool, error) {

--- a/hook/hooktest/hooktest.go
+++ b/hook/hooktest/hooktest.go
@@ -49,7 +49,10 @@ type Runner struct {
 	// that the hook tool runs successfully with no output.
 	RunFunc func(string, ...string) ([]byte, error)
 	Record  [][]string
-	Logger  interface {
+
+	// Logger should be set to a logger. The Logf method
+	// will be called when the charm generates log messages.
+	Logger interface {
 		Logf(string, ...interface{})
 	}
 
@@ -75,7 +78,7 @@ func (runner *Runner) RunHook(hookName string, relId hook.RelationId, relUnit ho
 	hctxt := &hook.Context{
 		UUID:         UUID,
 		Unit:         "someunit/0",
-		CharmDir:     "/nowhere",
+		CharmDir:     "/dev/null",
 		HookStateDir: runner.HookStateDir,
 
 		HookName:    hookName,

--- a/hook/registry.go
+++ b/hook/registry.go
@@ -115,7 +115,7 @@ func (r *Registry) RegisterHook(name string, f func() error) {
 }
 
 // RegisterContext registers a function that will be called
-// to set up a context before any hook function execution.
+// to set up a context before hook function execution.
 //
 // If state is non-nil, it should hold a pointer to a value
 // that will be used to hold persistent state associated with the


### PR DESCRIPTION
This makes it possible to write HTTP servers where all
the juju relation logic for the required relations is implied
by the type of a field in the argument to the handler.

So, for instance, if I want a charm that implements an HTTP
handler that requires a MongoDB connection, I can define
a handler creation function like:

     type relations struct {
         Session *mgo.Session
     }
     func newHandler(args struct{}, rel *relations) (httpservice.Handler, error) {
          ... I can use rel.Session how I like here.
     }

and register it as an HTTP server with:

      var svc httpservice.Service
      svc.Register(r.Clone("svc"), "httpservicename", "http", newHandler)

The handler will be created and destroyed as necessary when HTTP ports,
etc change, and when the relations change too.

This PR also fixes httpservice so that its server is long running - listeners
are started and stopped within the same process rather than (as previously)
rewriting the upstart file each time a service's parameters change.

It also adds mongodbrelation as an example and adds tests that it actually
works as advertised.