### PR TITLE
charmbits/httprelation: clarify and fix relation value ownership

### DIFF
--- a/charmbits/mongodbrelation/requirer.go
+++ b/charmbits/mongodbrelation/requirer.go
@@ -100,7 +100,7 @@ func registerField(r *hook.Registry, tag string) func() (interface{}, error) {
 	req.Register(r, relationName)
 	return func() (interface{}, error) {
 		if url := req.URL(); url != "" {
-			return relationInfo{
+			return &relationInfo{
 				URL: req.URL(),
 			}, nil
 		}
@@ -108,9 +108,14 @@ func registerField(r *hook.Registry, tag string) func() (interface{}, error) {
 	}
 }
 
-func setFieldValue(f **mgo.Session, info relationInfo) error {
+func setFieldValue(f **mgo.Session, info *relationInfo) error {
 	if *f != nil {
+		(*f).Close()
+		*f = nil
 		return httpservice.ErrRestartNeeded
+	}
+	if info == nil {
+		return nil
 	}
 	session, err := mgo.Dial(info.URL)
 	if err != nil {

--- a/charmbits/mongodbrelation/requirer_test.go
+++ b/charmbits/mongodbrelation/requirer_test.go
@@ -34,7 +34,7 @@ func (*suite) TestHTTPService(c *gc.C) {
 			svc.Register(r.Clone("svc"), "httpservicename", "http", func(_ struct{}, rel *relations) (httpservice.Handler, error) {
 				c.Logf("starting test handler")
 				return &testHandler{
-					session: rel.Session,
+					session: rel.Session.Copy(),
 				}, nil
 			})
 			r.RegisterHook("start", func() error {


### PR DESCRIPTION
Also fix the case where the httpservice handler only has one argument.